### PR TITLE
[fix] 중복이메일 예외처리 관련 수정(로그인)

### DIFF
--- a/src/main/java/com/example/ililbooks/domain/auth/google/service/AuthGoogleService.java
+++ b/src/main/java/com/example/ililbooks/domain/auth/google/service/AuthGoogleService.java
@@ -59,7 +59,7 @@ public class AuthGoogleService {
     @Transactional(readOnly = true)
     public AuthTokensResponse signIn(AuthGoogleAccessTokenRequest authGoogleAccessTokenRequest) {
         GoogleApiProfileResponse profile = getProfile(authGoogleAccessTokenRequest);
-        Users users = userService.findByEmailOrElseThrow(profile.email());
+        Users users = userService.findByEmailAndLoginTypeOrElseThrow(profile.email(), GOOGLE);
 
         if (users.isDeleted()) {
             throw new UnauthorizedException(DEACTIVATED_USER_EMAIL.getMessage());

--- a/src/main/java/com/example/ililbooks/domain/auth/naver/service/AuthNaverService.java
+++ b/src/main/java/com/example/ililbooks/domain/auth/naver/service/AuthNaverService.java
@@ -55,7 +55,7 @@ public class AuthNaverService {
     @Transactional(readOnly = true)
     public AuthTokensResponse signInWithNaver(AuthNaverAccessTokenRequest authNaverAccessTokenRequest) {
         NaverApiProfileResponse profile = getProfile(authNaverAccessTokenRequest);
-        Users users = userService.findByEmailOrElseThrow(profile.email());
+        Users users = userService.findByEmailAndLoginTypeOrElseThrow(profile.email(), NAVER);
 
         if (users.isDeleted()) {
             throw new UnauthorizedException(DEACTIVATED_USER_EMAIL.getMessage());

--- a/src/main/java/com/example/ililbooks/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/ililbooks/domain/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.example.ililbooks.domain.auth.dto.request.AuthSignUpRequest;
 import com.example.ililbooks.domain.auth.dto.response.AuthTokensResponse;
 import com.example.ililbooks.domain.auth.entity.RefreshToken;
 import com.example.ililbooks.domain.user.entity.Users;
+import com.example.ililbooks.domain.user.enums.LoginType;
 import com.example.ililbooks.domain.user.service.UserService;
 import com.example.ililbooks.global.exception.BadRequestException;
 import com.example.ililbooks.global.exception.UnauthorizedException;
@@ -13,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.ililbooks.domain.user.enums.LoginType.EMAIL;
 import static com.example.ililbooks.global.exception.ErrorMessage.*;
 
 @Service
@@ -39,7 +41,7 @@ public class AuthService {
     /* 로그인 */
     @Transactional(readOnly = true)
     public AuthTokensResponse signIn(AuthSignInRequest request) {
-        Users users = userService.findByEmailOrElseThrow(request.email());
+        Users users = userService.findByEmailAndLoginTypeOrElseThrow(request.email(), EMAIL);
 
         if (users.isDeleted()) {
             throw new UnauthorizedException(DEACTIVATED_USER_EMAIL.getMessage());

--- a/src/main/java/com/example/ililbooks/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/ililbooks/domain/user/repository/UserRepository.java
@@ -12,7 +12,7 @@ public interface UserRepository extends JpaRepository<Users, Long> {
 
     boolean existsByEmailAndLoginType(String email, LoginType loginType);
 
-    Optional<Users> findByEmail(@Param("email") String email);
+    Optional<Users> findByEmailAndLoginType(String email, LoginType loginType);
 
     @Query("SELECT u FROM Users u " +
             "WHERE u.id = :userId " +

--- a/src/main/java/com/example/ililbooks/domain/user/service/UserService.java
+++ b/src/main/java/com/example/ililbooks/domain/user/service/UserService.java
@@ -95,8 +95,8 @@ public class UserService {
         users.deleteUser();
     }
 
-    public Users findByEmailOrElseThrow(String email) {
-        return userRepository.findByEmail(email).orElseThrow(
+    public Users findByEmailAndLoginTypeOrElseThrow(String email, LoginType loginType) {
+        return userRepository.findByEmailAndLoginType(email, loginType).orElseThrow(
                 () -> new UnauthorizedException(USER_EMAIL_NOT_FOUND.getMessage())
         );
     }
@@ -117,7 +117,7 @@ public class UserService {
     * 없을 경우 email, nickname 값의 유저 생성 후 저장
     *  */
     public Users findByEmailOrGet(String email, String nickname, LoginType loginType) {
-        return userRepository.findByEmail(email)
+        return userRepository.findByEmailAndLoginType(email, loginType)
                 .orElseGet(() -> userRepository.save(
                         Users.builder()
                                 .email(email)

--- a/src/test/java/com/example/ililbooks/domain/auth/service/AuthGoogleServiceTest.java
+++ b/src/test/java/com/example/ililbooks/domain/auth/service/AuthGoogleServiceTest.java
@@ -150,7 +150,7 @@ class AuthGoogleServiceTest {
         ReflectionTestUtils.setField(users, "isDeleted", true);
 
         given(googleClient.findProfile(anyString())).willReturn(googleApiProfileResponse);
-        given(userService.findByEmailOrElseThrow(anyString())).willReturn(users);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(users);
 
         // when & given
         UnauthorizedException unauthorizedException = assertThrows(UnauthorizedException.class,
@@ -165,7 +165,7 @@ class AuthGoogleServiceTest {
         ReflectionTestUtils.setField(users, "loginType", LoginType.EMAIL);
 
         given(googleClient.findProfile(anyString())).willReturn(googleApiProfileResponse);
-        given(userService.findByEmailOrElseThrow(anyString())).willReturn(users);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(users);
 
         // when & given
         UnauthorizedException unauthorizedException = assertThrows(UnauthorizedException.class,
@@ -180,7 +180,7 @@ class AuthGoogleServiceTest {
         ReflectionTestUtils.setField(users, "loginType", LoginType.GOOGLE);
 
         given(googleClient.findProfile(anyString())).willReturn(googleApiProfileResponse);
-        given(userService.findByEmailOrElseThrow(anyString())).willReturn(users);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(users);
         given(authService.getTokenResponse(any(Users.class))).willReturn(authTokensResponse);
 
         // when

--- a/src/test/java/com/example/ililbooks/domain/auth/service/AuthNaverServiceTest.java
+++ b/src/test/java/com/example/ililbooks/domain/auth/service/AuthNaverServiceTest.java
@@ -131,7 +131,7 @@ public class AuthNaverServiceTest {
     void 조회한_프로필_이메일로_찾아지는_유저가_존재하지_않아_네이버_로그인_실패() {
         //given
         givenNaverProfile();
-        given(userService.findByEmailOrElseThrow(anyString())).willThrow(new UnauthorizedException());
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willThrow(new UnauthorizedException());
 
         //when & then
         assertThrows(UnauthorizedException.class,
@@ -146,7 +146,7 @@ public class AuthNaverServiceTest {
         ReflectionTestUtils.setField(TEST_NAVER_USERS, "isDeleted", true);
 
         givenNaverProfile();
-        given(userService.findByEmailOrElseThrow(anyString())).willReturn(TEST_NAVER_USERS);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(TEST_NAVER_USERS);
 
         //when & then
         assertThrows(UnauthorizedException.class,
@@ -162,7 +162,7 @@ public class AuthNaverServiceTest {
         ReflectionTestUtils.setField(TEST_NAVER_USERS, "loginType", LoginType.EMAIL);
 
         givenNaverProfile();
-        given(userService.findByEmailOrElseThrow(anyString())).willReturn(TEST_NAVER_USERS);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(TEST_NAVER_USERS);
 
         //when & then
         assertThrows(UnauthorizedException.class,
@@ -178,7 +178,7 @@ public class AuthNaverServiceTest {
         ReflectionTestUtils.setField(TEST_NAVER_USERS, "loginType", LoginType.NAVER);
 
         givenNaverProfile();
-        given(userService.findByEmailOrElseThrow(anyString())).willReturn(TEST_NAVER_USERS);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(TEST_NAVER_USERS);
         given(authService.getTokenResponse(TEST_NAVER_USERS)).willReturn(AUTH_TOKENS_RESPONSE);
 
         //when

--- a/src/test/java/com/example/ililbooks/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/ililbooks/domain/auth/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import com.example.ililbooks.domain.auth.dto.request.AuthSignUpRequest;
 import com.example.ililbooks.domain.auth.dto.response.AuthTokensResponse;
 import com.example.ililbooks.domain.auth.entity.RefreshToken;
 import com.example.ililbooks.domain.user.entity.Users;
+import com.example.ililbooks.domain.user.enums.LoginType;
 import com.example.ililbooks.domain.user.enums.UserRole;
 import com.example.ililbooks.domain.user.service.UserService;
 import com.example.ililbooks.global.exception.BadRequestException;
@@ -21,8 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static com.example.ililbooks.global.exception.ErrorMessage.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -108,7 +108,7 @@ public class AuthServiceTest {
         // given
         ReflectionTestUtils.setField(users, "isDeleted", true);
 
-        given(userService.findByEmailOrElseThrow(any(String.class))).willReturn(users);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(users);
 
         // when & then
         UnauthorizedException unauthorizedException = assertThrows(UnauthorizedException.class,
@@ -121,7 +121,7 @@ public class AuthServiceTest {
         // given
         ReflectionTestUtils.setField(users, "isDeleted", false);
 
-        given(userService.findByEmailOrElseThrow(any(String.class))).willReturn(users);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(users);
         given(passwordEncoder.matches(successSignIn.password(), users.getPassword())).willReturn(false);
 
         // when & then
@@ -138,7 +138,7 @@ public class AuthServiceTest {
         String accessToken = "accessToken";
         String refreshToken = "refreshToken";
 
-        given(userService.findByEmailOrElseThrow(any(String.class))).willReturn(users);
+        given(userService.findByEmailAndLoginTypeOrElseThrow(anyString(), any(LoginType.class))).willReturn(users);
         given(passwordEncoder.matches(successSignIn.password(), users.getPassword())).willReturn(true);
         given(tokenService.createAccessToken(any(Users.class))).willReturn(accessToken);
         given(tokenService.createRefreshToken(any(Users.class))).willReturn(refreshToken);

--- a/src/test/java/com/example/ililbooks/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/ililbooks/domain/user/service/UserServiceTest.java
@@ -255,11 +255,11 @@ class UserServiceTest {
     void 이메일로_유저_조회_실패() {
         // when
         String email = "email@email.com";
-        given(userRepository.findByEmail(anyString())).willReturn(Optional.empty());
+        given(userRepository.findByEmailAndLoginType(anyString(), any(LoginType.class))).willReturn(Optional.empty());
 
         // when & then
         UnauthorizedException unauthorizedException = assertThrows(UnauthorizedException.class,
-                () -> userService.findByEmailOrElseThrow(email));
+                () -> userService.findByEmailAndLoginTypeOrElseThrow(email, LoginType.EMAIL));
         assertEquals(unauthorizedException.getMessage(), USER_EMAIL_NOT_FOUND.getMessage());
     }
 
@@ -267,16 +267,16 @@ class UserServiceTest {
     void 이메일로_유저_조회_성공() {
         // when
         String email = "email@email.com";
-        given(userRepository.findByEmail(anyString())).willReturn(Optional.of(users));
+        given(userRepository.findByEmailAndLoginType(anyString(), any(LoginType.class))).willReturn(Optional.of(users));
 
         // when
-        Users result = userService.findByEmailOrElseThrow(email);
+        Users result = userService.findByEmailAndLoginTypeOrElseThrow(email, LoginType.EMAIL);
 
         // given
         assertEquals(users.getEmail(), result.getEmail());
         assertEquals(users.getNickname(), result.getNickname());
         assertEquals(users.getUserRole(), result.getUserRole());
-        verify(userRepository, times(1)).findByEmail(email);
+        verify(userRepository, times(1)).findByEmailAndLoginType(anyString(), any(LoginType.class));
     }
 
     /* findByIdOrElseThrow */


### PR DESCRIPTION
## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 로그인 타입이 다른 이메일을 다른 계정으로 인식하여 예외처리 하는 것으로 수정(로그인 로직 수정)
