### PR TITLE
[feat] 동시성테스트 CI 통과용으로 H2사용

### DIFF
--- a/src/test/java/com/example/ililbooks/concurrency/book/BookStockOptimisticLockTest.java
+++ b/src/test/java/com/example/ililbooks/concurrency/book/BookStockOptimisticLockTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Profile("test")
 @SpringBootTest
 class BookStockOptimisticLockTest {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,10 @@
+]spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true


### PR DESCRIPTION
## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 동시성 테스트가 CI 단계에서 실패하는 이유로 CI용 DB를 사용하는 방법을 사용함
- [X] application-test.yml를 따로 작성하여 H2를 사용할 수 있도록 설정


## 💡 PR 특이사항
CI에서 DB를 따로 작성 해주지 않고 돌리는 방법으로 H2를 사용하는 방법이 있다고 해서 한번 적용시켜보았습니다.
CI에서 실패가 지속적으로 발생할 경우 다시 재수정 및 해당 테스트를 주석처리 하는 것도 생각해보겠습니다...


## 📸 스크린샷
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/319ad33a-9a6c-49dc-ade3-7a6ad0f90329" />