### PR TITLE
[feat] 재고감소 롤백에 낙관락 적용 및 테스트 DB관련문제 해결

### DIFF
--- a/src/main/java/com/example/ililbooks/domain/book/entity/Book.java
+++ b/src/main/java/com/example/ililbooks/domain/book/entity/Book.java
@@ -140,5 +140,6 @@ public class Book extends TimeStamped {
         if (this.stock > 0 && this.saleStatus == SaleStatus.SOLD_OUT) {
             this.saleStatus = SaleStatus.ON_SALE;
         }
+        this.version++;
     }
 }

--- a/src/test/java/com/example/ililbooks/concurrency/book/BookStockOptimisticLockTest.java
+++ b/src/test/java/com/example/ililbooks/concurrency/book/BookStockOptimisticLockTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Profile("test")
+@ActiveProfiles("test")
 @SpringBootTest
 class BookStockOptimisticLockTest {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
-]spring:
+spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -8,3 +8,6 @@
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 주문감소 롤백에 동시성제어 추가
- [X] 동시성 제어 통과용으로 테스트 코드에 H2 사용(수정)


## 💡 PR 특이사항
테스트 코드를 돌릴때 로컬에서 데이터가 늘 저장되어 유저 및 책이 많이 저장되는 이슈가 있었는데 H2 DB를 사용하면서 해결했습니다.